### PR TITLE
ubuntu-specific build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 CLI client for RRIV
 
 # building
-## Linux
-1. sudo apt install libserial-dev
-2. sudo apt install cmake
-3. Enter the command `./compile.sh`
+## Pop Linux
+1. `sudo apt install cmake libserial-dev`
+2. Enter the command `./compile.sh`
 
-##macos
-1. Install homebrew if you have not already.
-2. 
+## Ubuntu
+1. `sudo apt install cmake pkg-config cmake-data libserial-dev`
+2. Enter the command `./compile.sh`
+
+## Macos (currently unsupported)
+1. ~Install homebrew if you have not already.~
 
 # running
 ./build/rriv-cli


### PR DESCRIPTION
The cmake incantation used here to find the installed libserial-dev relies on pkg-config.
Ubuntu doesn't seem to have it installed by default and cmake does not error when it is missing.