### PR TITLE
help() uses cmdList(), set-rtc and get-rtc have additional functionality

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -5,5 +5,5 @@ cmake ..
 cd ..
 make -C build
 
-#echo "Running executable"
-#./build/rriv-cli
+echo "Running executable: ./build/rriv-cli"
+./build/rriv-cli

--- a/lib/Cmd.cpp
+++ b/lib/Cmd.cpp
@@ -302,3 +302,21 @@ uint32_t cmdStr2Num(char *str, uint8_t base)
 {
     return strtol(str, NULL, base);
 }
+
+/**************************************************************************/
+/*!
+    List each command's name in the command table on a separate line
+*/
+/**************************************************************************/
+void cmdList()
+{
+    cmd_t *cmd_entry;
+    char buf[50];
+
+    // navigate the command table and print each name
+    for (cmd_entry = cmd_tbl; cmd_entry != NULL; cmd_entry = cmd_entry->next)
+    {
+        strcpy(buf, cmd_entry->cmd);
+        *outStream << buf << std::endl;
+    }
+}

--- a/lib/Cmd.h
+++ b/lib/Cmd.h
@@ -78,5 +78,6 @@ void cmdAdd(const char *name, void (*func)(int argc, char **argv));
 void cmdRun(const char * command);
 std::istream* cmdGetStream(void);
 uint32_t cmdStr2Num(char *str, uint8_t base);
+void cmdList();
 
 #endif //CMD_H

--- a/rriv-cli.cpp
+++ b/rriv-cli.cpp
@@ -30,33 +30,11 @@ std::string testResult;
 
 void help(int arg_cnt, char **args)
 {
-    char commands[] = "Command List:\n"
-                      "version\n"
-                      "show-warranty\n"
-                      "get-config\n"
-                      "set-config\n"
-                      "set-slot-config\n"
-                      "clear-slot\n"
-                      "set-rtc\n"
-                      "get-rtc\n"
-                      "restart\n"
-                      "set-site-name\n"
-                      "set-deployment-identifier\n"
-                      "set-interval\n"
-                      "set-burst-number\n"
-                      "set-start-up-delay\n"
-                      "set-burst-delay\n"
-                      "calibrate\n"
-                      "set-user-note\n"
-                      "set-user-value\n"
-                      "start-logging\n"
-                      "deploy-now\n"
-                      "interactive\n"
-                      "trace\n"
-                      "check-memory\n"
-                      "scan-ic2\n";
-
-    std::cout << commands << std::endl;
+    cout << "CLI-Client Command List:" << endl;
+    cmdList();
+    
+    serial_port->Write("help\r\n");
+    serial_port->DrainWriteBuffer();
 }
 
 void setRTC(int arg_cnt, char **args)
@@ -69,6 +47,19 @@ void setRTC(int arg_cnt, char **args)
     timeStringStream << time;
 
     serial_port->Write("set-rtc " + timeStringStream.str() + "\r\n");
+    serial_port->DrainWriteBuffer();
+}
+
+void getRTC(int arg_cnt, char **args)
+{
+    performingRelay = true;
+    std::time_t time = std::time(nullptr);
+    //std::cout << asctime(std::localtime(&time)) << time << std::endl;
+
+    std::stringstream timeStringStream;
+    timeStringStream << time;
+
+    serial_port->Write("get-rtc " + timeStringStream.str() + "\r\n");
     serial_port->DrainWriteBuffer();
 }
 
@@ -125,7 +116,7 @@ void loadConfigFromFile(int arg_cnt, char **args)
 
 void relay(int arg_cnt, char **args)
 {
-    cout << "relay" << endl;
+    // cout << "relay" << endl;
     performingRelay = true;
     for (int i = 0; i < arg_cnt; i++)
     {
@@ -136,7 +127,7 @@ void relay(int arg_cnt, char **args)
         }
     }
     serial_port->Write("\r\n");
-    cout << "sent" << endl;
+    // cout << "sent" << endl;
 }
 
 void echo(int arg_cnt, char ** args)
@@ -283,7 +274,7 @@ int ensureDeviceConnected()
         // serial_port->SetParity(Parity::PARITY_NONE);
         // serial_port->SetStopBits(StopBits::STOP_BITS_1);
 
-        serial_port->Write("restart\r\n");
+        // serial_port->Write("restart\r\n");
         serial_port->DrainWriteBuffer();
     }
     catch (const std::exception &exc)
@@ -318,6 +309,7 @@ int main(int argc, char *argv[])
     cmdInit(&std::cin, &std::cout);
     cmdAdd("help", help);
     cmdAdd("set-rtc", setRTC);
+    cmdAdd("get-rtc", getRTC);
     cmdAdd("run-workflow", runWorkflow);
     cmdAdd("run-test", runTest);
     cmdAdd("load-config", loadConfigFromFile);
@@ -351,7 +343,7 @@ int main(int argc, char *argv[])
                 {
                     continue;
                 }
-                std::cerr << exc.what();
+                // std::cerr << exc.what();
             }
 
             // readString = string("CMD >>\r");


### PR DESCRIPTION
cmdList() implemented in cmdArduino.git, so will be necessary to pair with this change
this change affects the help() command which now lists out all cli commands currently enabled, rather than us manually maintaining a list of commands

set-rtc and get-rtc are modified to work with my versions of them, mainly to provide differences from previous times set, allowing for monitoring of time drift on the RTC, or for debugging any other issues that may occur with them, like when setting the time incorrectly was causing a strange roll over effect at the end of a month